### PR TITLE
Add TYD implementation with vault integration

### DIFF
--- a/src/AdapterStrategy.sol
+++ b/src/AdapterStrategy.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import {IAdapterCallbacks} from "./interfaces/IAdapterCallbacks.sol";
+import {IUniversalRouterAdapterStrategy} from "./interfaces/IUniversalRouterAdapterStrategy.sol";
+
+abstract contract AdapterStrategy is IUniversalRouterAdapterStrategy {
+    error NotAdapter();
+
+    modifier onlyAdapter() {
+        if (msg.sender != address(adapter)) revert NotAdapter();
+        _;
+    }
+
+    IAdapterCallbacks public immutable adapter;
+
+    constructor(address _adapter) {
+        adapter = IAdapterCallbacks(_adapter);
+    }
+}

--- a/src/OracleCouncil.sol
+++ b/src/OracleCouncil.sol
@@ -344,8 +344,8 @@ contract OracleCouncil is
         uint256 _rewardAmount,
         string memory _yesTokenSymbol,
         string memory _noTokenSymbol
-    ) external nonReentrant whenNotPaused onlyCouncilMembers {
-        marketManager.createMarket(
+    ) public {
+        createMarketWithPaymentToken(
             _marketQuestion,
             _marketSource,
             _additionalInfo,
@@ -354,7 +354,45 @@ contract OracleCouncil is
             _rewardToken,
             _rewardAmount,
             _yesTokenSymbol,
-            _noTokenSymbol
+            _noTokenSymbol,
+            marketManager.paymentToken()
+        );
+    }
+
+    /// @notice Creates a new market with a specified payment token
+    /// @param _marketQuestion The question that the market will resolve
+    /// @param _marketSource The source that will be used to verify the outcome
+    /// @param _additionalInfo Additional information about the market
+    /// @param _endOfTrading The timestamp when trading will end
+    /// @param _yesNoTokenCap The maximum amount of YES/NO tokens that can be minted
+    /// @param _rewardToken The token used for rewards
+    /// @param _rewardAmount The amount of reward tokens
+    /// @param _yesTokenSymbol The symbol for the YES token
+    /// @param _noTokenSymbol The symbol for the NO token
+    /// @param _paymentToken The token to be used for payment in this market
+    function createMarketWithPaymentToken(
+        string memory _marketQuestion,
+        string memory _marketSource,
+        string memory _additionalInfo,
+        uint256 _endOfTrading,
+        uint256 _yesNoTokenCap,
+        address _rewardToken,
+        uint256 _rewardAmount,
+        string memory _yesTokenSymbol,
+        string memory _noTokenSymbol,
+        address _paymentToken
+    ) public nonReentrant whenNotPaused onlyCouncilMembers {
+        marketManager.createMarketWithPaymentToken(
+            _marketQuestion,
+            _marketSource,
+            _additionalInfo,
+            _endOfTrading,
+            _yesNoTokenCap,
+            _rewardToken,
+            _rewardAmount,
+            _yesTokenSymbol,
+            _noTokenSymbol,
+            _paymentToken
         );
     }
 

--- a/src/SweepStrategy.sol
+++ b/src/SweepStrategy.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import {ActionConstants} from "@uniswap/v4-periphery/src/libraries/ActionConstants.sol";
+import {AdapterStrategy} from "./AdapterStrategy.sol";
+
+contract SweepStrategy is AdapterStrategy {
+    error UnsupportedRecipient();
+
+    constructor(address _adapter) AdapterStrategy(_adapter) {}
+
+    function beforeExecute(uint256, bytes calldata inputs, address msgSender)
+        external
+        view
+        override
+        onlyAdapter
+        returns (PackedApproval[] memory approvals, bytes memory modifiedInputs)
+    {
+        (address token, address recipient, uint256 amountMin) = _parseInputs(inputs);
+
+        if (recipient != msgSender && recipient != ActionConstants.MSG_SENDER) {
+            revert UnsupportedRecipient();
+        }
+
+        approvals = new PackedApproval[](0);
+
+        modifiedInputs = abi.encode(token, address(adapter), amountMin);
+    }
+
+    function afterExecute(uint256 command, bytes calldata inputs, address msgSender) external override onlyAdapter {
+        (address token,,) = _parseInputs(inputs);
+
+        uint256 amount = IERC20(token).balanceOf(address(adapter));
+
+        if (amount > 0) {
+            adapter.transferTo(command, msgSender, amount, address(token));
+        }
+    }
+
+    function _parseInputs(bytes calldata inputs)
+        internal
+        pure
+        returns (address token, address recipient, uint256 amountMin)
+    {
+        assembly {
+            token := calldataload(inputs.offset)
+            recipient := calldataload(add(inputs.offset, 0x20))
+            amountMin := calldataload(add(inputs.offset, 0x40))
+        }
+    }
+}

--- a/src/TruthMarket.sol
+++ b/src/TruthMarket.sol
@@ -31,7 +31,7 @@ contract TruthMarket is Initializable, OwnableUpgradeable, OraclePausable, Reent
         uint256 outcome;
     }
 
-    string public constant VERSION = "1.1.0";
+    string public constant VERSION = "1.2.0";
 
     uint256 private constant _HUNDRED = 100;
     uint256 private constant _ONE_PERCENT = 1e16;
@@ -100,6 +100,7 @@ contract TruthMarket is Initializable, OwnableUpgradeable, OraclePausable, Reent
     event FirstChallengePeriodChanged(uint256 firstChallengePeriod);
     event SecondChallengePeriodChanged(uint256 secondChallengePeriod);
     event RewardReceiverBlacklisted(address indexed token, address indexed account);
+    event RewardTransferred(address indexed token, address indexed receiverAccount, uint256 amount);
 
     error TokenCapExceeded();
     error MarketNotInTradingPhase();
@@ -540,8 +541,10 @@ contract TruthMarket is Initializable, OwnableUpgradeable, OraclePausable, Reent
         if (isBlacklisted) {
             rewardToken.safeTransfer(marketManager.safeBoxAddress(), rewardAmount);
             emit RewardReceiverBlacklisted(address(rewardToken), _receiver);
+            emit RewardTransferred(address(rewardToken), marketManager.safeBoxAddress(), rewardAmount);
         } else {
             rewardToken.safeTransfer(_receiver, rewardAmount);
+            emit RewardTransferred(address(rewardToken), _receiver, rewardAmount);
         }
     }
 

--- a/src/TruthMarketAdapter.sol
+++ b/src/TruthMarketAdapter.sol
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import "./interfaces/ITruthMarket.sol";
+
+/**
+ * @title TruthMarketAdapter
+ * @notice Adapter contract to interact with TruthMarket using ERC4626 vault tokens
+ * @dev This contract handles the conversion between asset tokens and vault share tokens when interacting with TruthMarket
+ * This contract is upgradeable using the UUPS pattern
+ */
+contract TruthMarketAdapter is 
+    Initializable, 
+    UUPSUpgradeable, 
+    OwnableUpgradeable, 
+    ReentrancyGuardUpgradeable
+{
+    using SafeERC20 for IERC20;
+    
+    /// @notice The asset token (e.g., USDC)
+    IERC20 public assetToken;
+    
+    /// @notice The ERC4626 vault contract
+    IERC4626 public vault;
+    
+    /// @notice Custom error for invalid winning position
+    error InvalidWinningPosition(uint256 position);
+    
+    /// @notice Custom error for zero share amount received
+    error ZeroSharesReceived();
+
+    /// @notice Custom error for zero YES or NO token received
+    error ZeroYESOrNoTokenReceived();
+    
+    /// @notice Custom error for payment token mismatch
+    error PaymentTokenMismatch(address expected, address actual);
+    
+    /**
+     * @notice Emitted when vault address is updated (assetToken is derived from vault)
+     * @param assetToken New asset token address
+     * @param vault New vault address
+     */
+    event VaultUpdated(address assetToken, address vault);
+    
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+    
+    /**
+     * @notice Initializes the contract replacing the constructor for upgradeable contracts
+     * @param _vault Address of the ERC4626 vault contract
+     */
+    function initialize(
+        address _vault
+    ) external initializer {
+        __Ownable_init();
+        __ReentrancyGuard_init();
+        __UUPSUpgradeable_init();
+        
+        vault = IERC4626(_vault);
+        assetToken = IERC20(vault.asset());
+    }
+    
+    /**
+     * @notice Mints YES/NO tokens by depositing asset token into vault first to get vault share token
+     * @param truthMarket Address of the TruthMarket contract
+     * @param assetAmount Amount of asset token to deposit
+     */
+    function mint(address truthMarket, uint256 assetAmount) external nonReentrant {
+        ITruthMarket market = ITruthMarket(truthMarket);
+        
+        // Verify that market's payment token matches our vault
+        address marketPaymentToken = market.paymentToken();
+        if (marketPaymentToken != address(vault)) {
+            revert PaymentTokenMismatch(address(vault), marketPaymentToken);
+        }
+        
+        // Transfer asset token from user to this contract
+        assetToken.safeTransferFrom(msg.sender, address(this), assetAmount);
+        
+        // Approve vault to spend asset token
+        assetToken.approve(address(vault), assetAmount);
+        
+        // Deposit asset token to vault to get vault share token
+        // This step converts from assetToken to vault shares
+        uint256 shareAmount = vault.deposit(assetAmount, address(this));
+        
+        // Approve TruthMarket to spend vault share token
+        IERC20(address(vault)).approve(truthMarket, shareAmount);
+        
+        // Get YES/NO token addresses
+        address yesToken = market.yesToken();
+        address noToken = market.noToken();
+        
+        // Record YES/NO token balances before mint
+        uint256 yesBalanceBefore = IERC20(yesToken).balanceOf(address(this));
+        uint256 noBalanceBefore = IERC20(noToken).balanceOf(address(this));
+        
+        // Mint YES/NO tokens by calling TruthMarket.mint()
+        market.mint(shareAmount);
+        
+        // Calculate actual YES/NO tokens received using balance delta
+        uint256 yesBalanceAfter = IERC20(yesToken).balanceOf(address(this));
+        uint256 noBalanceAfter = IERC20(noToken).balanceOf(address(this));
+        
+        uint256 yesTokensReceived = yesBalanceAfter - yesBalanceBefore;
+        uint256 noTokensReceived = noBalanceAfter - noBalanceBefore;
+        
+        if (yesTokensReceived == 0 || noTokensReceived == 0) {
+            revert ZeroYESOrNoTokenReceived();
+        }
+        
+        // Transfer YES and NO tokens to user
+        IERC20(yesToken).transfer(msg.sender, yesTokensReceived);
+        IERC20(noToken).transfer(msg.sender, noTokensReceived);
+    }
+    
+    /**
+     * @notice Burns YES/NO tokens and returns asset token to user after withdrawing from vault
+     * @param truthMarket Address of the TruthMarket contract
+     * @param amount Amount of YES/NO tokens to burn
+     */
+    function burn(address truthMarket, uint256 amount) external nonReentrant {
+        ITruthMarket market = ITruthMarket(truthMarket);
+        
+        // Verify that market's payment token matches our vault
+        address marketPaymentToken = market.paymentToken();
+        if (marketPaymentToken != address(vault)) {
+            revert PaymentTokenMismatch(address(vault), marketPaymentToken);
+        }
+        
+        // Get YES/NO token addresses
+        address yesToken = market.yesToken();
+        address noToken = market.noToken();
+        
+        // Transfer YES and NO tokens from user to this contract
+        IERC20(yesToken).safeTransferFrom(msg.sender, address(this), amount);
+        IERC20(noToken).safeTransferFrom(msg.sender, address(this), amount);
+        
+        // Approve TruthMarket to spend YES and NO tokens
+        IERC20(yesToken).approve(truthMarket, amount);
+        IERC20(noToken).approve(truthMarket, amount);
+        
+        // Record vault share balance before burning
+        uint256 vaultSharesBefore = IERC20(address(vault)).balanceOf(address(this));
+        
+        // Burn YES/NO tokens to get vault share token
+        market.burn(amount);
+        
+        // Calculate actual vault shares received using balance delta
+        uint256 vaultSharesAfter = IERC20(address(vault)).balanceOf(address(this));
+        uint256 sharesReceived = vaultSharesAfter - vaultSharesBefore;
+        
+        if (sharesReceived == 0) {
+            revert ZeroSharesReceived();
+        }
+        
+        // Withdraw asset token from vault directly to user
+        vault.redeem(sharesReceived, msg.sender, address(this));
+    }
+    
+    /**
+     * @notice Redeems winning tokens and returns asset token to user after withdrawing from vault
+     * @param truthMarket Address of the TruthMarket contract
+     * @param amount Amount of winning tokens to redeem
+     */
+    function redeem(address truthMarket, uint256 amount) external nonReentrant {
+        ITruthMarket market = ITruthMarket(truthMarket);
+        
+        // Verify that market's payment token matches our vault
+        address marketPaymentToken = market.paymentToken();
+        if (marketPaymentToken != address(vault)) {
+            revert PaymentTokenMismatch(address(vault), marketPaymentToken);
+        }
+        
+        // Get YES/NO token addresses and check winning position
+        address yesToken = market.yesToken();
+        address noToken = market.noToken();
+        uint256 winningPosition = market.winningPosition();
+        
+        // Transfer winning tokens from user to this contract
+        if (winningPosition == 1) { // YES won
+            IERC20(yesToken).safeTransferFrom(msg.sender, address(this), amount);
+            IERC20(yesToken).approve(truthMarket, amount);
+        } else if (winningPosition == 2) { // NO won
+            IERC20(noToken).safeTransferFrom(msg.sender, address(this), amount);
+            IERC20(noToken).approve(truthMarket, amount);
+        } else {
+            revert InvalidWinningPosition(winningPosition);
+        }
+        
+        // Record vault share balance before redeeming
+        uint256 vaultSharesBefore = IERC20(address(vault)).balanceOf(address(this));
+        
+        // Redeem winning tokens to get vault share token
+        market.redeem(amount);
+        
+        // Calculate actual vault shares received using balance delta
+        uint256 vaultSharesAfter = IERC20(address(vault)).balanceOf(address(this));
+        uint256 sharesReceived = vaultSharesAfter - vaultSharesBefore;
+        
+        if (sharesReceived == 0) {
+            revert ZeroSharesReceived();
+        }
+        
+        // Withdraw asset token from vault directly to user
+        vault.redeem(sharesReceived, msg.sender, address(this));
+    }
+    
+    /**
+     * @notice Withdraws from canceled market and returns asset token to user after withdrawing from vault
+     * @param truthMarket Address of the TruthMarket contract
+     */
+    function withdrawFromCanceledMarket(address truthMarket) external nonReentrant {
+        ITruthMarket market = ITruthMarket(truthMarket);
+        
+        // Verify that market's payment token matches our vault
+        address marketPaymentToken = market.paymentToken();
+        if (marketPaymentToken != address(vault)) {
+            revert PaymentTokenMismatch(address(vault), marketPaymentToken);
+        }
+        
+        // Get YES/NO token addresses
+        address yesToken = market.yesToken();
+        address noToken = market.noToken();
+        
+        // Get user's YES and NO token balances
+        uint256 yesBalance = IERC20(yesToken).balanceOf(msg.sender);
+        uint256 noBalance = IERC20(noToken).balanceOf(msg.sender);
+        
+        // Transfer all YES and NO tokens from user to this contract
+        if (yesBalance > 0) {
+            IERC20(yesToken).safeTransferFrom(msg.sender, address(this), yesBalance);
+            IERC20(yesToken).approve(truthMarket, yesBalance);
+        }
+        
+        if (noBalance > 0) {
+            IERC20(noToken).safeTransferFrom(msg.sender, address(this), noBalance);
+            IERC20(noToken).approve(truthMarket, noBalance);
+        }
+        
+        // Record vault share balance before withdrawing
+        uint256 vaultSharesBefore = IERC20(address(vault)).balanceOf(address(this));
+        
+        // Withdraw from canceled market to get vault share token
+        market.withdrawFromCanceledMarket();
+        
+        // Calculate actual vault shares received using balance delta
+        uint256 vaultSharesAfter = IERC20(address(vault)).balanceOf(address(this));
+        uint256 sharesReceived = vaultSharesAfter - vaultSharesBefore;
+        
+        if (sharesReceived == 0) {
+            revert ZeroSharesReceived();
+        }
+        
+        // Withdraw asset token from vault directly to user
+        vault.redeem(sharesReceived, msg.sender, address(this));
+    }
+    
+    /**
+     * @notice Rescues any tokens accidentally sent to this contract
+     * @param token Address of the token to rescue
+     * @param to Address to send the tokens to
+     * @param amount Amount of tokens to rescue
+     */
+    function rescueTokens(address token, address to, uint256 amount) external onlyOwner {
+        IERC20(token).safeTransfer(to, amount);
+    }
+    
+    /**
+     * @notice Updates the vault address and retrieves the associated asset token
+     * @param _vault New address of the ERC4626 vault
+     */
+    function setVault(
+        address _vault
+    ) external onlyOwner {
+        vault = IERC4626(_vault);
+        assetToken = IERC20(vault.asset());
+
+        emit VaultUpdated(vault.asset(), _vault);
+    }
+    
+    /**
+     * @notice Function that should revert when msg.sender is not authorized to upgrade the contract
+     * @dev Called by the upgradeable proxy contract
+     * @param newImplementation The address of the new implementation contract
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+}

--- a/src/TruthMarketManager.sol
+++ b/src/TruthMarketManager.sol
@@ -187,7 +187,45 @@ contract TruthMarketManager is
         uint256 _rewardAmount,
         string memory _yesTokenSymbol,
         string memory _noTokenSymbol
-    ) external nonReentrant whenNotPaused onlyOracleCouncilAndOwner {
+    ) external {
+        // Call the new createMarketWithPaymentToken function with the system's default paymentToken
+        createMarketWithPaymentToken(
+            _marketQuestion,
+            _marketSource,
+            _additionalInfo,
+            _endOfTrading,
+            _yesNoTokenCap,
+            _rewardToken,
+            _rewardAmount,
+            _yesTokenSymbol,
+            _noTokenSymbol,
+            paymentToken
+        );
+    }
+
+    /// @notice Creates a new market with a specified payment token
+    /// @param _marketQuestion The question that the market will resolve
+    /// @param _marketSource The source that will be used to verify the outcome
+    /// @param _additionalInfo Additional information about the market
+    /// @param _endOfTrading The timestamp when trading will end
+    /// @param _yesNoTokenCap The maximum amount of YES/NO tokens that can be minted
+    /// @param _rewardToken The token used for rewards
+    /// @param _rewardAmount The amount of reward tokens
+    /// @param _yesTokenSymbol The symbol for the YES token (optional)
+    /// @param _noTokenSymbol The symbol for the NO token (optional)
+    /// @param _paymentToken The token to be used for payment in this market
+    function createMarketWithPaymentToken(
+        string memory _marketQuestion,
+        string memory _marketSource,
+        string memory _additionalInfo,
+        uint256 _endOfTrading,
+        uint256 _yesNoTokenCap,
+        address _rewardToken,
+        uint256 _rewardAmount,
+        string memory _yesTokenSymbol,
+        string memory _noTokenSymbol,
+        address _paymentToken
+    ) public nonReentrant whenNotPaused onlyOracleCouncilAndOwner {
         if (_endOfTrading < block.timestamp + minimumTradingDuration) {
             revert InvalidEndOfTrading();
         }
@@ -197,7 +235,9 @@ contract TruthMarketManager is
         if (bytes(_marketSource).length == 0 ) {
             revert InvalidSource();
         }
-
+        if (_paymentToken == address(0)) {
+            revert InvalidAddress();
+        }
         if (rewardWallet == address(0)) {
             revert InvalidRewardWallet();
         }
@@ -225,7 +265,7 @@ contract TruthMarketManager is
             _additionalInfo,
             _endOfTrading,
             _yesNoTokenCap,
-            address(paymentToken),
+            _paymentToken, // Use the specified payment token instead of the system default
             address(yesToken),
             address(noToken),
             _rewardToken,

--- a/src/UniversalRouterAdapter.sol
+++ b/src/UniversalRouterAdapter.sol
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IUniversalRouter} from "@uniswap/universal-router/contracts/interfaces/IUniversalRouter.sol";
+import {Commands} from "@uniswap/universal-router/contracts/libraries/Commands.sol";
+import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
+import {IAdapterCallbacks} from "./interfaces/IAdapterCallbacks.sol";
+import {IUniversalRouterAdapter} from "./interfaces/IUniversalRouterAdapter.sol";
+import {IUniversalRouterAdapterStrategy} from "./interfaces/IUniversalRouterAdapterStrategy.sol";
+
+contract UniversalRouterAdapter is 
+    IAdapterCallbacks, 
+    IUniversalRouterAdapter, 
+    Initializable,
+    UUPSUpgradeable,
+    OwnableUpgradeable, 
+    ReentrancyGuardUpgradeable 
+{
+    using SafeERC20 for IERC20;
+
+    IUniversalRouter public universalRouter;
+    IAllowanceTransfer public permit2;
+    address public vault;
+    address public asset;
+
+    mapping(uint256 => IUniversalRouterAdapterStrategy) public strategies;
+    mapping(uint256 => bool) public commandWhitelist;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initializes the contract replacing the constructor for upgradeable contracts
+     * @param _universalRouter Address of the Uniswap Universal Router
+     * @param _permit2 Address of the Permit2 contract
+     * @param _vault Address of the ERC4626 vault contract
+     */
+    function initialize(
+        address _universalRouter,
+        address _permit2,
+        address _vault
+    ) external initializer {
+        __Ownable_init();
+        __ReentrancyGuard_init();
+        __UUPSUpgradeable_init();
+        
+        universalRouter = IUniversalRouter(_universalRouter);
+        permit2 = IAllowanceTransfer(_permit2);
+        vault = _vault;
+        asset = IERC4626(_vault).asset();
+    }
+
+    /**
+     * @notice Authorizes contract upgrades
+     * @param newImplementation Address of the new implementation
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+
+    modifier onlyStrategy(uint256 command) {
+        if (address(strategies[command]) != msg.sender) revert IAdapterCallbacks.NotAuthorized();
+        _;
+    }
+
+    function setCommandWhitelist(uint256 command, bool whitelist) external onlyOwner {
+        commandWhitelist[command] = whitelist;
+    }
+
+    function setStrategy(uint256 command, IUniversalRouterAdapterStrategy strategy) external onlyOwner {
+        strategies[command] = strategy;
+    }
+
+    function execute(bytes calldata commands, bytes[] calldata inputs, uint256 deadline) external payable {
+        if (block.timestamp > deadline) revert IUniversalRouter.TransactionDeadlinePassed();
+        execute(commands, inputs);
+    }
+
+    function execute(bytes calldata commands, bytes[] calldata inputs) public payable {
+        uint256 numCommands = commands.length;
+
+        bytes[] memory modifiedInputs = new bytes[](numCommands);
+
+        if (inputs.length != numCommands) revert IUniversalRouter.LengthMismatch();
+
+        for (uint256 i = 0; i < numCommands; i++) {
+            bytes1 commandType = commands[i];
+            uint256 command = uint8(commandType & Commands.COMMAND_TYPE_MASK);
+
+            if (!commandWhitelist[command]) revert CommandNotWhitelisted();
+
+            bytes calldata input = inputs[i];
+            modifiedInputs[i] = input;
+            IUniversalRouterAdapterStrategy strategy = strategies[command];
+
+            if (address(strategy) != address(0)) {
+                (IUniversalRouterAdapterStrategy.PackedApproval[] memory approvals, bytes memory modifiedInput) =
+                    strategy.beforeExecute(command, input, msg.sender);
+
+                if (modifiedInput.length > 0) {
+                    modifiedInputs[i] = modifiedInput;
+                }
+
+                _batchApprove(approvals);
+            }
+        }
+
+        universalRouter.execute(commands, modifiedInputs, block.timestamp);
+
+        // @note execute in reverse order
+        for (uint256 i = numCommands; i > 0; i--) {
+            bytes1 commandType = commands[i - 1];
+            uint256 command = uint8(commandType & Commands.COMMAND_TYPE_MASK);
+            bytes memory input = modifiedInputs[i - 1];
+            IUniversalRouterAdapterStrategy strategy = strategies[command];
+
+            if (address(strategy) != address(0)) {
+                strategy.afterExecute(command, input, msg.sender);
+            }
+        }
+    }
+
+    function permit2TransferFrom(uint256 fromCommand, address from, uint256 amount, address token)
+        external
+        override
+        nonReentrant
+        onlyStrategy(fromCommand)
+        returns (uint256 actualAmount)
+    {
+        if (token == vault) {
+            // amount = desired vault shares
+            // Convert shares to required assets using previewMint
+            uint256 assets = IERC4626(vault).previewMint(amount);
+
+            // Security check: ensure assets fits in uint160 for Permit2
+            if (assets > type(uint160).max) {
+                revert ExceedPermit2Limit();
+            }
+
+            permit2.transferFrom(from, address(this), uint160(assets), asset);
+            IERC20(asset).forceApprove(vault, assets);
+            actualAmount = IERC4626(vault).deposit(assets, address(this));
+        } else {
+            permit2.transferFrom(from, address(this), uint160(amount), token);
+            actualAmount = amount;
+        }
+    }
+
+    function transferTo(uint256 fromCommand, address to, uint256 amount, address token)
+        external
+        override
+        nonReentrant
+        onlyStrategy(fromCommand)
+    {
+        if (token == vault) {
+            IERC4626(vault).redeem(amount, to, address(this));
+        } else {
+            IERC20(token).transfer(to, amount);
+        }
+    }
+
+    function _increaseAllowance(address token, address spender, uint256 amount) internal {
+        uint256 allowance = IERC20(token).allowance(address(this), spender);
+        IERC20(token).forceApprove(spender, allowance + amount);
+    }
+
+    function _increasePermit2Allowance(address token, address spender, uint256 amount) internal {
+        (uint160 oldAmount, uint48 expiration,) = permit2.allowance(address(this), token, spender);
+        if (block.timestamp > expiration) {
+            oldAmount = 0;
+        }
+        // @note ask allowance for every single transaction, the expiration is always current block timestamp
+        permit2.approve(token, spender, uint160(oldAmount + amount), uint48(block.timestamp));
+    }
+
+    function _batchApprove(IUniversalRouterAdapterStrategy.PackedApproval[] memory approvals) internal {
+        for (uint256 j = 0; j < approvals.length; j++) {
+            _increaseAllowance(approvals[j].token, address(permit2), approvals[j].amount);
+            _increasePermit2Allowance(approvals[j].token, address(universalRouter), approvals[j].amount);
+        }
+    }
+}

--- a/src/V3SwapStrategy.sol
+++ b/src/V3SwapStrategy.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Commands} from "@uniswap/universal-router/contracts/libraries/Commands.sol";
+import {ActionConstants} from "@uniswap/v4-periphery/src/libraries/ActionConstants.sol";
+import {BytesLib} from "@uniswap/universal-router/contracts/modules/uniswap/v3/BytesLib.sol";
+import {V3Path} from "@uniswap/universal-router/contracts/modules/uniswap/v3/V3Path.sol";
+import {CalldataDecoder} from "@uniswap/v4-periphery/src/libraries/CalldataDecoder.sol";
+import {AdapterStrategy} from "./AdapterStrategy.sol";
+
+contract V3SwapStrategy is AdapterStrategy {
+    using BytesLib for bytes;
+    using CalldataDecoder for bytes;
+    using V3Path for bytes;
+    using SafeERC20 for IERC20;
+
+    error UnsupportedRecipient();
+    error UnsupportedPayer();
+
+    constructor(address _adapter) AdapterStrategy(_adapter) {}
+
+    function beforeExecute(uint256 command, bytes calldata inputs, address msgSender)
+        external
+        override
+        onlyAdapter
+        returns (PackedApproval[] memory approvals, bytes memory modifiedInputs)
+    {
+        bool isExactInput;
+        address recipient;
+        uint256 amountIn;
+        uint256 amountOut;
+        bool payerIsUser;
+
+        if (command == Commands.V3_SWAP_EXACT_IN) {
+            isExactInput = true;
+            (recipient, amountIn, amountOut, payerIsUser) = _parseExactInInputs(inputs);
+        } else {
+            isExactInput = false;
+            (recipient, amountOut, amountIn, payerIsUser) = _parseExactOutInputs(inputs);
+        }
+
+        if (
+            recipient != msgSender && recipient != ActionConstants.MSG_SENDER
+                && recipient != ActionConstants.ADDRESS_THIS
+        ) {
+            revert UnsupportedRecipient();
+        }
+
+        if (!payerIsUser) revert UnsupportedPayer();
+
+        bytes calldata path = inputs.toBytes(3);
+
+        (address tokenIn,, address tokenOut) = path.decodeFirstPool();
+
+        address tokenToApprove = isExactInput ? tokenIn : tokenOut;
+
+        amountIn = adapter.permit2TransferFrom(command, msgSender, amountIn, address(tokenToApprove));
+
+        approvals = new PackedApproval[](1);
+        approvals[0] = PackedApproval(tokenToApprove, amountIn);
+
+        // @note Under normal circumstances, using address this as the recipient is paired with the sweep command.
+        // Using address this as the recipient can also be paired with the pay portion command,
+        // but the user needs to end with a sweep command to reclaim the assets.
+        // - When the recipient is msgSender, this strategy will change the recipient to the adapter.
+        //   The asset will be returned directly to msgSender from the adapter after afterExecute.
+        // - When the recipient is address(this), the asset will have its recipient changed to the adapter in
+        //   the sweep command strategy’s beforeExecute, and will be returned from the adapter in afterExecute.
+        if (recipient == ActionConstants.ADDRESS_THIS) {
+            // do nothing
+        } else if (command == Commands.V3_SWAP_EXACT_IN) {
+            modifiedInputs = abi.encode(address(adapter), amountIn, amountOut, path, true);
+        } else {
+            modifiedInputs = abi.encode(address(adapter), amountOut, amountIn, path, true);
+        }
+    }
+
+    function afterExecute(uint256 command, bytes calldata inputs, address msgSender) external override onlyAdapter {
+        bool isExactInput;
+
+        if (command == Commands.V3_SWAP_EXACT_IN) {
+            isExactInput = true;
+        } else {
+            isExactInput = false;
+        }
+
+        bytes calldata path = inputs.toBytes(3);
+
+        (address tokenIn,, address tokenOut) = path.decodeFirstPool();
+
+        if (!isExactInput) {
+            (tokenIn, tokenOut) = (tokenOut, tokenIn);
+        }
+
+        uint256 remainingTokenIn = IERC20(tokenIn).balanceOf(address(adapter));
+
+        if (remainingTokenIn > 0) {
+            // return all remaining tokenIn to the msg sender
+            adapter.transferTo(command, msgSender, remainingTokenIn, address(tokenIn));
+        }
+
+        uint256 amountTokenOut = IERC20(tokenOut).balanceOf(address(adapter));
+
+        if (amountTokenOut > 0) {
+            // return all token out to the msg sender
+            adapter.transferTo(command, msgSender, amountTokenOut, address(tokenOut));
+        }
+    }
+
+    function _parseExactInInputs(bytes calldata inputs)
+        internal
+        pure
+        returns (address recipient, uint256 amountIn, uint256 amountOutMin, bool payerIsUser)
+    {
+        // equivalent: abi.decode(inputs, (address, uint256, uint256, bytes, bool))
+        assembly {
+            recipient := calldataload(inputs.offset)
+            amountIn := calldataload(add(inputs.offset, 0x20))
+            amountOutMin := calldataload(add(inputs.offset, 0x40))
+            payerIsUser := calldataload(add(inputs.offset, 0x80))
+        }
+    }
+
+    function _parseExactOutInputs(bytes calldata inputs)
+        internal
+        pure
+        returns (address recipient, uint256 amountOut, uint256 amountInMax, bool payerIsUser)
+    {
+        // equivalent: abi.decode(inputs, (address, uint256, uint256, bytes, bool))
+        assembly {
+            recipient := calldataload(inputs.offset)
+            amountOut := calldataload(add(inputs.offset, 0x20))
+            amountInMax := calldataload(add(inputs.offset, 0x40))
+            payerIsUser := calldataload(add(inputs.offset, 0x80))
+        }
+    }
+}

--- a/src/interfaces/IAdapterCallbacks.sol
+++ b/src/interfaces/IAdapterCallbacks.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IAdapterCallbacks {
+    // callback msg.sender is not registered strategy contract.
+    error NotAuthorized();
+    error ExceedPermit2Limit();
+
+    // Always transfers from an external address to the adapter contract.
+    // If the token is an ERC4626 vault token, will auto deposit before transfer.
+    // Strategy contract can collect tokens from users via this callback.
+    function permit2TransferFrom(uint256 fromCommand, address from, uint256 amount, address token)
+        external
+        returns (uint256 actualAmount);
+
+    // Always transfers from the adapter contract to an external address.
+    // If the token is an ERC4626 vault token, will auto redeem before transfer.
+    function transferTo(uint256 fromCommand, address to, uint256 amount, address token) external;
+}

--- a/src/interfaces/IUniversalRouterAdapter.sol
+++ b/src/interfaces/IUniversalRouterAdapter.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IUniversalRouterAdapter {
+    error BatchExecuteNotSupported();
+    error CommandNotWhitelisted();
+
+    function execute(bytes calldata commands, bytes[] calldata inputs) external payable;
+
+    function execute(bytes calldata commands, bytes[] calldata inputs, uint256 deadline) external payable;
+}

--- a/src/interfaces/IUniversalRouterAdapterStrategy.sol
+++ b/src/interfaces/IUniversalRouterAdapterStrategy.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IUniversalRouterAdapterStrategy {
+    struct PackedApproval {
+        address token;
+        uint256 amount;
+    }
+
+    /// @notice Called before the execute function of the UniversalRouterAdapter
+    /// @param command The command type to execute
+    /// @param inputs The inputs to execute the command with
+    /// @param msgSender The address of the message sender
+    /// @return approvals The approvals to increase the allowance for
+    /// @return modifiedInputs The modified inputs to execute the command with
+    function beforeExecute(uint256 command, bytes calldata inputs, address msgSender)
+        external
+        returns (PackedApproval[] memory approvals, bytes memory modifiedInputs);
+    function afterExecute(uint256 command, bytes calldata inputs, address msgSender) external;
+}


### PR DESCRIPTION
  ## Summary
  - Updates Oracle contracts (OracleBonds, OracleCouncil) to support TYD functionality
  - Enhances TruthMarket and TruthMarketManager for vault interactions
  - Adds helper contracts to facilitate conversion between asset tokens and vault share
  tokens

  ## Changes
  - **Modified contracts:**
    - `OracleBonds.sol` - Updated for TYD support
    - `OracleCouncil.sol` - Enhanced with vault integration capabilities
    - `TruthMarket.sol` - Added vault interaction support
    - `TruthMarketManager.sol` - Extended for TYD functionality

  - **New helper contracts:**
    - `UniversalRouterAdapter.sol` - Facilitates token conversions through Uniswap
    - `TruthMarketAdapter.sol` - Bridges TruthMarket with vault tokens

  - **New strategies:**
    - `V3SwapStrategy.sol` - Uniswap V3 swap implementation
    - `SweepStrategy.sol` - Token sweep functionality
    - `AdapterStrategy.sol` - Base adapter strategy implementation

  - **New interfaces:**
    - `IAdapterCallbacks.sol`
    - `IUniversalRouterAdapter.sol`
    - `IUniversalRouterAdapterStrategy.sol`