### PR TITLE
Fix range order validation and partial fill logic

### DIFF
--- a/src/interfaces/IDistributor.sol
+++ b/src/interfaces/IDistributor.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "./ILaunchpadViewer.sol";
+
+interface IDistributor {
+    event DistributeErc20(uint256 proposalId, address market, address erc20, uint256 amount);
+    event DistributeErc721(uint256 proposalId, address market, address erc721, uint256 id);
+    event DistributeErc1155(uint256 proposalId, address market, address erc1155, uint256 id, uint256 amount);
+
+    function distribute(ILaunchpadViewer viewer, uint256 proposalId, address market) external;
+}

--- a/src/interfaces/IOrderManager.sol
+++ b/src/interfaces/IOrderManager.sol
@@ -4,6 +4,7 @@ import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
+import {Order} from "../libraries/Order.sol";
 
 interface IOrderManager {
     error Unauthorized();
@@ -44,7 +45,7 @@ interface IOrderManager {
         uint256 liquidity
     );
 
-    event MinimumLiteralAmountUpdated(address indexed token, uint256 minimumLiteralAmount);
+    event MinimumOrderAmountUpdated(address indexed token, uint256 minimumOrderAmount);
 
     event MaximumExecutionCountUpdated(uint256 maximumExecutionCount);
 
@@ -71,15 +72,6 @@ interface IOrderManager {
 
     event AdminSafeUpdated(address indexed adminSafe);
 
-    struct PendingOrder {
-        address owner;
-        bool zeroForOne;
-        int24 tickLower;
-        int24 tickUpper;
-        uint256 liquidity;
-        bool enablePartialFill;
-    }
-
     struct CreateOrderParams {
         PoolKey poolKey;
         uint128 amountIn;
@@ -96,10 +88,10 @@ interface IOrderManager {
         uint128 amount1Min;
     }
 
-    /// @notice Sets the minimum literal amount required for a specific token
+    /// @notice Sets the minimum order amount required for a specific token
     /// @param token The token address to set the minimum for
-    /// @param minimumLiteralAmount_ The new minimum literal amount for this token
-    function setMinimumLiteralAmount(address token, uint256 minimumLiteralAmount_) external;
+    /// @param minimumOrderAmount_ The new minimum order amount for this token
+    function setMinimumOrderAmount(address token, uint256 minimumOrderAmount_) external;
 
     /// @notice Sets the maximum number of orders that can be executed in a single transaction
     /// @param maximumExecutionCount_ The new maximum execution count
@@ -143,7 +135,7 @@ interface IOrderManager {
     /// @param poolId The ID of the pool containing the order
     /// @param orderId The ID of the order to query
     /// @return The pending order details
-    function pendingOrder(PoolId poolId, uint32 orderId) external view returns (PendingOrder memory);
+    function pendingOrder(PoolId poolId, uint32 orderId) external view returns (Order memory);
 
     /// @notice Rescues tokens from the contract
     /// @param token The token to rescue

--- a/src/interfaces/ISwapValidator.sol
+++ b/src/interfaces/ISwapValidator.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.8.24;
 
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 
@@ -19,4 +20,10 @@ interface ISwapValidator {
         BalanceDelta delta,
         bytes calldata hookData
     ) external;
+
+    /// @notice Sets tick boundaries for a pool
+    /// @param poolId The pool ID
+    /// @param tickLowerBoundary The lower tick boundary
+    /// @param tickUpperBoundary The upper tick boundary
+    function setBoundaries(PoolId poolId, int24 tickLowerBoundary, int24 tickUpperBoundary) external;
 }

--- a/src/libraries/Order.sol
+++ b/src/libraries/Order.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+struct Order {
+    address owner;
+    bool zeroForOne;
+    int24 tickLower;
+    int24 tickUpper;
+    uint256 liquidity;
+    bool enablePartialFill;
+}
+
+library OrderLibrary {
+    function partialThresholdLower(Order memory order, int24 tickSpacing) internal pure returns (int24) {
+        return order.zeroForOne ? order.tickLower + tickSpacing : order.tickLower;
+    }
+
+    function partialThresholdUpper(Order memory order, int24 tickSpacing) internal pure returns (int24) {
+        return order.zeroForOne ? order.tickUpper : order.tickUpper - tickSpacing;
+    }
+
+    function fulfillThreshold(Order memory order) internal pure returns (int24) {
+        return order.zeroForOne ? order.tickUpper : order.tickLower;
+    }
+}

--- a/src/libraries/OrderValidation.sol
+++ b/src/libraries/OrderValidation.sol
@@ -9,7 +9,7 @@ library OrderValidation {
 
     error InvalidTickThreshold(int24 currentTick, int24 tickThreshold, bool zeroForOne);
 
-    error InsufficientOrderAmount(uint128 amountIn, uint8 decimals, uint256 minimumLiteralAmount);
+    error InsufficientOrderAmount(uint128 amountIn, uint256 minimumOrderAmount);
 
     function validateTickRange(int24 tickLower, int24 tickUpper, int24 tickSpacing, bool enablePartialFill)
         internal
@@ -32,30 +32,23 @@ library OrderValidation {
         }
     }
 
-    function validateTickThreshold(int24 tick, int24 tickLower, int24 tickUpper, int24 tickThreshold, bool zeroForOne)
-        internal
-        pure
-    {
+    function validateTickThreshold(int24 tick, int24 tickLower, int24 tickUpper, bool zeroForOne) internal pure {
         if (zeroForOne && tick >= tickLower) {
-            revert InvalidTickThreshold(tick, tickThreshold, zeroForOne);
+            revert InvalidTickThreshold(tick, tickLower, zeroForOne);
         }
 
         if (!zeroForOne && tick <= tickUpper) {
-            revert InvalidTickThreshold(tick, tickThreshold, zeroForOne);
+            revert InvalidTickThreshold(tick, tickUpper, zeroForOne);
         }
     }
 
-    function validateMinimumAmount(address token, uint128 amount, uint256 minimumLiteralAmount) internal view {
-        if (minimumLiteralAmount == 0) {
+    function validateMinimumAmount(uint128 amount, uint256 minimumOrderAmount) internal view {
+        if (minimumOrderAmount == 0) {
             return;
         }
 
-        uint8 decimals = IERC20Metadata(token).decimals();
-
-        uint256 literalAmount = amount / (10 ** decimals);
-
-        if (literalAmount < minimumLiteralAmount) {
-            revert InsufficientOrderAmount(amount, decimals, minimumLiteralAmount);
+        if (amount < minimumOrderAmount) {
+            revert InsufficientOrderAmount(amount, minimumOrderAmount);
         }
     }
 }

--- a/src/libraries/TransientUint32Set.sol
+++ b/src/libraries/TransientUint32Set.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @notice In-memory (transaction scoped) uint32 set built on EIP-1153 transient storage.
+library TransientUint32Set {
+    type Set is bytes32;
+
+    error IndexOutOfBounds(uint256 index, uint256 length);
+
+    function wrap(bytes32 slot) internal pure returns (Set) {
+        return Set.wrap(slot);
+    }
+
+    function length(Set set) internal view returns (uint256 result) {
+        bytes32 slot = Set.unwrap(set);
+        assembly ("memory-safe") {
+            result := tload(slot)
+        }
+    }
+
+    function contains(Set set, uint32 value) internal view returns (bool) {
+        return _loadUint(_indexSlot(set, value)) != 0;
+    }
+
+    function at(Set set, uint256 index) internal view returns (uint32) {
+        uint256 len = length(set);
+        if (index >= len) revert IndexOutOfBounds(index, len);
+
+        return uint32(_loadUint(_valueSlot(set, index)));
+    }
+
+    function values(Set set) internal view returns (uint32[] memory result) {
+        uint256 len = length(set);
+        result = new uint32[](len);
+
+        for (uint256 i; i < len; ++i) {
+            result[i] = at(set, i);
+        }
+    }
+
+    function add(Set set, uint32 value) internal returns (bool) {
+        bytes32 indexSlot = _indexSlot(set, value);
+
+        if (_loadUint(indexSlot) != 0) return false;
+
+        bytes32 lengthSlot = Set.unwrap(set);
+        uint256 len = _loadUint(lengthSlot);
+        uint256 newLen = len + 1;
+
+        _storeUint(_valueSlot(set, len), value);
+        _storeUint(indexSlot, newLen);
+        _storeUint(lengthSlot, newLen);
+
+        return true;
+    }
+
+    function remove(Set set, uint32 value) internal returns (bool) {
+        bytes32 indexSlot = _indexSlot(set, value);
+        uint256 indexPlusOne = _loadUint(indexSlot);
+
+        if (indexPlusOne == 0) return false;
+
+        bytes32 lengthSlot = Set.unwrap(set);
+        uint256 len = _loadUint(lengthSlot);
+        uint256 index = indexPlusOne - 1;
+        uint256 lastIndex = len - 1;
+
+        if (index != lastIndex) {
+            bytes32 lastValueSlot = _valueSlot(set, lastIndex);
+            uint256 lastValue = _loadUint(lastValueSlot);
+
+            _storeUint(_valueSlot(set, index), lastValue);
+            _storeUint(_indexSlot(set, uint32(lastValue)), index + 1);
+        }
+
+        _storeUint(_valueSlot(set, lastIndex), 0);
+        _storeUint(indexSlot, 0);
+        _storeUint(lengthSlot, len - 1);
+
+        return true;
+    }
+
+    function _loadUint(bytes32 slot) private view returns (uint256 result) {
+        assembly ("memory-safe") {
+            result := tload(slot)
+        }
+    }
+
+    function _storeUint(bytes32 slot, uint256 value) private {
+        assembly ("memory-safe") {
+            tstore(slot, value)
+        }
+    }
+
+    function _valueBaseSlot(Set set) private pure returns (bytes32 result) {
+        bytes32 slot = Set.unwrap(set);
+        assembly ("memory-safe") {
+            mstore(0x00, slot)
+            result := keccak256(0x00, 0x20)
+        }
+    }
+
+    function _valueSlot(Set set, uint256 index) private pure returns (bytes32 result) {
+        bytes32 base = _valueBaseSlot(set);
+        assembly ("memory-safe") {
+            result := add(base, index)
+        }
+    }
+
+    function _indexBaseSlot(Set set) private pure returns (bytes32) {
+        return bytes32(uint256(Set.unwrap(set)) ^ uint256(1));
+    }
+
+    function _indexSlot(Set set, uint32 value) private pure returns (bytes32 result) {
+        bytes32 base = _indexBaseSlot(set);
+        assembly ("memory-safe") {
+            mstore(0x00, value)
+            mstore(0x20, base)
+            result := keccak256(0x00, 0x40)
+        }
+    }
+}

--- a/src/validators/TruthMarketSwapValidator.sol
+++ b/src/validators/TruthMarketSwapValidator.sol
@@ -1,0 +1,84 @@
+pragma solidity ^0.8.24;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
+import {ISwapValidator} from "../interfaces/ISwapValidator.sol";
+import {Roles} from "../libraries/Roles.sol";
+
+contract TruthMarketSwapValidator is ISwapValidator, AccessControl {
+    using StateLibrary for IPoolManager;
+    using PoolIdLibrary for PoolKey;
+
+    // State variables
+    IPoolManager public immutable poolManager;
+
+    struct PoolBoundaries {
+        int24 tickLowerBoundary;
+        int24 tickUpperBoundary;
+        bool isSet;
+    }
+
+    mapping(PoolId => PoolBoundaries) public poolBoundaries;
+
+    // Errors
+    error TickOutOfBounds(int24 currentTick, int24 lowerBound, int24 upperBound);
+    error InvalidBoundaries();
+
+    // Events
+    event BoundariesUpdated(PoolId indexed poolId, int24 newLower, int24 newUpper);
+
+    constructor(IPoolManager _poolManager, address _admin) {
+        poolManager = _poolManager;
+        _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+    }
+
+    function validateAfterSwap(address, PoolKey calldata poolKey, SwapParams calldata, BalanceDelta, bytes calldata)
+        external
+        view
+        override
+    {
+        PoolId poolId = poolKey.toId();
+        PoolBoundaries memory boundaries = poolBoundaries[poolId];
+
+        // If boundaries haven't been set for this pool, use TickMath min/max
+        int24 lowerBound;
+        int24 upperBound;
+
+        if (!boundaries.isSet) {
+            lowerBound = TickMath.MIN_TICK;
+            upperBound = TickMath.MAX_TICK;
+        } else {
+            lowerBound = boundaries.tickLowerBoundary;
+            upperBound = boundaries.tickUpperBoundary;
+        }
+
+        // Get current tick after swap
+        (, int24 currentTick,,) = poolManager.getSlot0(poolId);
+
+        // Check boundaries
+        if (currentTick < lowerBound || currentTick > upperBound) {
+            revert TickOutOfBounds(currentTick, lowerBound, upperBound);
+        }
+    }
+
+    function setBoundaries(PoolId poolId, int24 _tickLowerBoundary, int24 _tickUpperBoundary)
+        external
+        onlyRole(Roles.OPERATOR_ROLE)
+    {
+        if (_tickLowerBoundary >= _tickUpperBoundary) revert InvalidBoundaries();
+
+        poolBoundaries[poolId] = PoolBoundaries({
+            tickLowerBoundary: _tickLowerBoundary,
+            tickUpperBoundary: _tickUpperBoundary,
+            isSet: true
+        });
+
+        emit BoundariesUpdated(poolId, _tickLowerBoundary, _tickUpperBoundary);
+    }
+}


### PR DESCRIPTION
This commit addresses several issues in the OrderManager related to range order handling, tick threshold validation, and partial fill execution.

## Key Changes

### Order Structure Refactoring
- Replace `PendingOrder` struct with `Order` library type
- Add `Order.sol` library with helper methods:
  - `fulfillThreshold()` - calculates single tick threshold for full execution
  - `partialThresholdLower()` - calculates lower tick threshold for partial fills
  - `partialThresholdUpper()` - calculates upper tick threshold for partial fills

### Tick Threshold Validation Fix
- Remove redundant `tickThreshold` parameter from validation
- Simplify `validateTickThreshold()` to directly check tickLower/tickUpper
- Validate zeroForOne orders against tickLower
- Validate oneForZero orders against tickUpper

### Minimum Amount Validation Refactor
- Rename `minimumLiteralAmount` to `minimumOrderAmount` for clarity
- Remove token decimals conversion logic
- Direct comparison of raw amount against minimum threshold
- Simplify validation error handling

### Partial Fill Improvements
- Add boundary checks for partial fill tick range adjustment
- Prevent invalid tick ranges when currentTick is at boundaries:
  - For zeroForOne: ensure `newTickLower < newTickUpper` by adjusting lower bound
  - For oneForZero: ensure `newTickLower < newTickUpper` by adjusting upper bound
- Return early if no valid partial fill range exists
- Update storage after partial fill calculations

### Order Execution Deduplication
- Add `TransientUint32Set` for tracking executing orders
- Prevent duplicate order execution within single transaction
- Use execution nonce to isolate order sets per execution
- Skip orders already being processed

### Execution Tick Adjustment
- Add boundary validation when deferred execution tick differs from current tick
- Adjust execution range when current tick has moved
- Skip execution if tick has moved out of range completely

### ISwapValidator Interface Extension
- Add `setBoundaries()` method for configuring tick boundaries per pool
- Support dynamic boundary management for swap validation

### New Supporting Files
- `src/libraries/Order.sol` - Order struct and helper methods
- `src/libraries/TransientUint32Set.sol` - Transient storage set for order tracking
- `src/validators/TruthMarketSwapValidator.sol` - Swap validation implementation
- `src/interfaces/IDistributor.sol` - Distributor interface

## Technical Details

### Tick Threshold Logic
Previously, tick threshold was derived during validation. Now it's calculated on-demand using Order library methods based on order direction and partial fill settings.

### Partial Fill Boundary Fix
When tick moves exactly to tickLower (zeroForOne) or tickUpper (oneForZero), the previous logic could create invalid ranges. New logic ensures valid ranges by adjusting bounds with tickSpacing offset.

### Minimum Amount Simplification
Old approach converted to "literal amount" by dividing by decimals, then compared. New approach directly compares raw amounts, making validation more predictable and gas-efficient.