### PR TITLE
docs: add Guardian Audits report to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ For contract addresses, versions, and configuration parameters, see [network_con
 
 ## Audits
 
+- **[Guardian Audits](https://github.com/GuardianAudits/Audits/tree/main/Trueo)**
 - **[iosiro](https://iosiro.com/audits/truth-markets-v2-smart-contract-audit)**
 
 ## Links


### PR DESCRIPTION
## Summary

Add the Guardian Audits report to the Audits section of the README, listed ahead of the existing iosiro entry.

- Report: https://github.com/GuardianAudits/Audits/tree/main/Trueo